### PR TITLE
Send SMS via Twilio for Fettle orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ gem 'messaging_service', git: 'git@github.com:sh24/messaging-service.git'
 Example usage:
 
 ```
-MessagingService::SMS.new(voodoo: <voodoo_config>, notifier: Airbrake)..send(to: <to_number>, message: <message>)
+MessagingService::SMS.new(voodoo_credentials: <voodoo_config>, twilio_credentials: <twilio_config>, primary_provider: :voodoo, fallback_provider: :twilio, notifier: Airbrake)
 ```
 
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+dependencies:
+  pre:
+    - gem install bundler

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -48,8 +48,9 @@ module MessagingService
     end
 
     private def send_with_twilio(to:, message:, **_)
-      twilio_service.account.messages.create(from: @twilio_credentials.number, to: to, body: message)
-      SMSResponse.new(true, 'twilio')
+      message = twilio_service.account.messages.create from: @twilio_credentials.number, to: to, body: message
+      reference_id = message.sid if message
+      SMSResponse.new true, 'twilio', reference_id
     end
 
     private def fallback_provider_provided?

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -27,14 +27,14 @@ module MessagingService
       SMSResponse.new(false)
     end
 
-    private def send_with_primary_provider(**arguments)
-      return send_with_twilio(arguments) if twilio_primary_provider?
-      return send_with_voodoo(arguments) if voodoo_primary_provider?
+    private def send_with_primary_provider(to:, message:, timeout:)
+      return send_with_twilio(to: to, message: message) if twilio_primary_provider?
+      return send_with_voodoo(to: to, message: message, timeout: timeout) if voodoo_primary_provider?
     end
 
-    private def send_with_fallback_provider(**arguments)
-      return send_with_voodoo(arguments) if voodoo_fallback_provider?
-      return send_with_twilio(arguments) if twilio_fallback_provider?
+    private def send_with_fallback_provider(to:, message:, timeout:)
+      return send_with_voodoo(to: to, message: message, timeout: timeout) if voodoo_fallback_provider?
+      return send_with_twilio(to: to, message: message) if twilio_fallback_provider?
     rescue StandardError => e
       notify(e)
       SMSResponse.new(false)
@@ -47,7 +47,7 @@ module MessagingService
       end
     end
 
-    private def send_with_twilio(to:, message:, **_)
+    private def send_with_twilio(to:, message:)
       message = twilio_service.account.messages.create from: @twilio_credentials[:number], to: to, body: message
       reference_id = message.sid if message
       SMSResponse.new true, 'twilio', reference_id

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -8,27 +8,31 @@ module MessagingService
     SMSResponse          = Struct.new(:success, :service_provider, :reference_id)
     OVERRIDE_VOODOO_FILE = 'tmp/OVERRIDE_VOODOO'.freeze
 
-    def initialize(voodoo_credentials:, twilio_credentials: nil, notifier: nil)
+    def initialize(voodoo_credentials: nil, twilio_credentials: nil, fallback_provider: nil, notifier: nil)
       @voodoo_credentials = voodoo_credentials
       @twilio_credentials = twilio_credentials
+      @fallback_provider  = fallback_provider
       @notifier           = notifier
     end
 
     def send(to:, message:, timeout: 15)
-      if fallback_allowed? && voodoo_overriden?
+      if twilio_credentials_provided? && voodoo_overriden?
         response = send_with_twilio(to: to, message: message)
         return response if response.success
       end
-      Timeout.timeout(timeout){ send_with_voodoo(to: to, message: message) }
+
+      send_with_voodoo to: to, message: message, timeout: timeout
     rescue => e
       return send_with_twilio(to: to, message: message) if fallback_allowed?
       notify(e)
       SMSResponse.new(false)
     end
 
-    private def send_with_voodoo(to:, message:)
-      reference_id = voodoo_service.send_sms(@voodoo_credentials.number, to, message)
-      SMSResponse.new(true, 'voodoo', reference_id)
+    private def send_with_voodoo(to:, message:, timeout:)
+      Timeout.timeout(timeout) do
+        reference_id = voodoo_service.send_sms(@voodoo_credentials.number, to, message)
+        SMSResponse.new(true, 'voodoo', reference_id)
+      end
     end
 
     private def send_with_twilio(to:, message:)
@@ -40,7 +44,7 @@ module MessagingService
     end
 
     private def fallback_allowed?
-      !@twilio_credentials.nil?
+      !@fallback_provider.nil?
     end
 
     private def voodoo_overriden?
@@ -57,6 +61,10 @@ module MessagingService
 
     private def notify error
       @notifier&.notify(error)
+    end
+
+    private def twilio_credentials_provided?
+      !@twilio_credentials.nil?
     end
 
   end

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -6,7 +6,7 @@ module MessagingService
   class SMS
 
     SMSResponse          = Struct.new(:success, :service_provider, :reference_id)
-    OVERRIDE_VOODOO_FILE = 'tmp/OVERRIDE_VOODOO'.freeze
+    OVERRIDE_VOODOO_FILE = 'tmp/OVERRIDE_VOODOO'
 
     def initialize(voodoo_credentials: nil, twilio_credentials: nil, primary_provider:, fallback_provider: nil, notifier: nil)
       raise_argument_error if no_credentials_provided?(voodoo_credentials, twilio_credentials)

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -47,7 +47,7 @@ module MessagingService
       end
     end
 
-    private def send_with_twilio(to:, message:, **)
+    private def send_with_twilio(to:, message:, **_)
       twilio_service.account.messages.create(from: @twilio_credentials.number, to: to, body: message)
       SMSResponse.new(true, 'twilio')
     end

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -42,13 +42,13 @@ module MessagingService
 
     private def send_with_voodoo(to:, message:, timeout: 15)
       Timeout.timeout(timeout) do
-        reference_id = voodoo_service.send_sms(@voodoo_credentials.number, to, message)
+        reference_id = voodoo_service.send_sms(@voodoo_credentials[:number], to, message)
         SMSResponse.new(true, 'voodoo', reference_id)
       end
     end
 
     private def send_with_twilio(to:, message:, **_)
-      message = twilio_service.account.messages.create from: @twilio_credentials.number, to: to, body: message
+      message = twilio_service.account.messages.create from: @twilio_credentials[:number], to: to, body: message
       reference_id = message.sid if message
       SMSResponse.new true, 'twilio', reference_id
     end
@@ -62,11 +62,11 @@ module MessagingService
     end
 
     private def twilio_service
-      Twilio::REST::Client.new @twilio_credentials.username, @twilio_credentials.password
+      Twilio::REST::Client.new @twilio_credentials[:username], @twilio_credentials[:password]
     end
 
     private def voodoo_service
-      VoodooSMS.new @voodoo_credentials.username, @voodoo_credentials.password
+      VoodooSMS.new @voodoo_credentials[:username], @voodoo_credentials[:password]
     end
 
     private def notify error

--- a/lib/messaging_service/version.rb
+++ b/lib/messaging_service/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessagingService
-  VERSION = '3.0.0'
+  VERSION = '3.0.0'.freeze
 end

--- a/lib/messaging_service/version.rb
+++ b/lib/messaging_service/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessagingService
-  VERSION = '3.0.0'.freeze
+  VERSION = '3.0.0'
 end

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -52,7 +52,7 @@ describe MessagingService::SMS do
     end
 
     context 'with fallback enabled' do
-      subject{ described_class.new(voodoo_credentials: voodoo_credentials, twilio_credentials: twilio_credentials, notifier: notifier) }
+      subject{ described_class.new(voodoo_credentials: voodoo_credentials, twilio_credentials: twilio_credentials, notifier: notifier, fallback_provider: :twilio) }
 
       it 'falls back to another service when the primary service fails' do
         VCR.use_cassette('voodoo_sms/bad_request') do
@@ -84,7 +84,7 @@ describe MessagingService::SMS do
       end
 
       context 'when fallback is enabled' do
-        subject{ described_class.new(voodoo_credentials: voodoo_credentials, twilio_credentials: twilio_credentials, notifier: notifier) }
+        subject{ described_class.new(voodoo_credentials: voodoo_credentials, twilio_credentials: twilio_credentials, fallback_provider: :twilio, notifier: notifier) }
 
         it 'tries Twilio first' do
           expect(Twilio::REST::Client).to receive_message_chain(:new, :account, :messages, :create)

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -11,8 +11,8 @@ class TestClient
 end
 
 describe MessagingService::SMS do
-  let(:voodoo_credentials){ double :voodoo_credentials, number: '440000000000', password: 'password', username: 'username' }
-  let(:twilio_credentials){ double :voodoo_credentials, number: '440000000000', password: 'auth_token', username: 'account_id' }
+  let(:voodoo_credentials){ { number: '440000000000', password: 'password', username: 'username' } }
+  let(:twilio_credentials){ { number: '440000000000', password: 'auth_token', username: 'account_id' } }
   let(:to_number){ '4499810123123' }
   let(:message){ 'Test SMS from RSpec' }
   let(:notifier){ double :notifier, notify: true }

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -11,14 +11,13 @@ class TestClient
 end
 
 describe MessagingService::SMS do
-  let(:voodoo_sender_id){ '440000000000' }
-  let(:voodoo_config){ double :voodoo_config, number: voodoo_sender_id, password: 'password', username: 'username' }
-  let(:twilio_sender_id){ '440000000000' }
-  let(:twilio_config){ double :voodoo_config, number: twilio_sender_id, password: 'auth_token', username: 'account_id' }
+  let(:voodoo_credentials){ double :voodoo_credentials, number: '440000000000', password: 'password', username: 'username' }
+  let(:twilio_credentials){ double :voodoo_credentials, number: '440000000000', password: 'auth_token', username: 'account_id' }
   let(:to_number){ '4499810123123' }
   let(:message){ 'Test SMS from RSpec' }
   let(:notifier){ double :notifier, notify: true }
-  subject{ described_class.new(voodoo: voodoo_config, notifier: notifier) }
+
+  subject{ described_class.new(voodoo_credentials: voodoo_credentials, notifier: notifier) }
 
   describe '#send' do
     context 'when voodoo times out' do
@@ -42,7 +41,7 @@ describe MessagingService::SMS do
 
     it 'returns false if message fails to send' do
       expect(notifier).to receive(:notify)
-      expect(MessagingService::SMS.new(voodoo: nil, notifier: notifier).send(to: to_number, message: message).success).to be false
+      expect(MessagingService::SMS.new(voodoo_credentials: nil, notifier: notifier).send(to: to_number, message: message).success).to be false
     end
 
     it 'returns false if message fails to send' do
@@ -53,7 +52,7 @@ describe MessagingService::SMS do
     end
 
     context 'with fallback enabled' do
-      subject{ described_class.new(voodoo: voodoo_config, fallback_twilio: twilio_config, notifier: notifier) }
+      subject{ described_class.new(voodoo_credentials: voodoo_credentials, twilio_credentials: twilio_credentials, notifier: notifier) }
 
       it 'falls back to another service when the primary service fails' do
         VCR.use_cassette('voodoo_sms/bad_request') do
@@ -85,7 +84,7 @@ describe MessagingService::SMS do
       end
 
       context 'when fallback is enabled' do
-        subject{ described_class.new(voodoo: voodoo_config, fallback_twilio: twilio_config, notifier: notifier) }
+        subject{ described_class.new(voodoo_credentials: voodoo_credentials, twilio_credentials: twilio_credentials, notifier: notifier) }
 
         it 'tries Twilio first' do
           expect(Twilio::REST::Client).to receive_message_chain(:new, :account, :messages, :create)

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -57,6 +57,7 @@ describe MessagingService::SMS do
         VCR.use_cassette('twilio/send') do
           response = subject.send(to: to_number, message: message)
           expect(response.success).to be_truthy
+          expect(response.reference_id).to eq 'SM0b54a4a40c4d42c9a518a7cdc18c5647'
           expect(response.service_provider).to eq 'twilio'
         end
       end


### PR DESCRIPTION
[PT](https://www.pivotaltracker.com/story/show/152672358)

This PR allows us to provide credentials for either Voodoo or Twilio (or both) and set them as primary/fallback providers to send SMS with. Voodoo override should work as before.