### PR TITLE
Update Twilio gem to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    messaging_service (4.0.0)
+    messaging_service (4.0.1)
       airbrake (> 4.0.0)
       twilio-ruby (~> 5.0)
       voodoo_sms (~> 1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     messaging_service (4.0.0)
       airbrake (> 4.0.0)
-      twilio-ruby (~> 3.14.0)
+      twilio-ruby (~> 5.0)
       voodoo_sms (~> 1.1.1)
 
 GEM
@@ -14,18 +14,20 @@ GEM
       airbrake-ruby (~> 2.5)
     airbrake-ruby (2.6.0)
     ast (2.3.0)
-    builder (3.2.3)
     byebug (9.0.6)
     coderay (1.1.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    faraday (0.13.1)
+      multipart-post (>= 1.2, < 3)
     httparty (0.15.6)
       multi_xml (>= 0.5.2)
     jwt (1.5.6)
+    libxml-ruby (3.0.0)
     method_source (0.8.2)
-    multi_json (1.12.2)
     multi_xml (0.6.0)
+    multipart-post (2.0.0)
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -67,10 +69,10 @@ GEM
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     tins (1.15.1)
-    twilio-ruby (3.14.5)
-      builder (>= 2.1.2)
-      jwt (~> 1.0)
-      multi_json (>= 1.3.0)
+    twilio-ruby (5.4.5)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      libxml-ruby (>= 2.0, < 4.0)
     unicode-display_width (1.2.1)
     vcr (2.9.3)
     voodoo_sms (1.1.1)
@@ -96,4 +98,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -52,7 +52,7 @@ module MessagingService
     end
 
     private def send_with_twilio(to:, message:)
-      message = twilio_service.account.messages.create from: @twilio_credentials[:number], to: to, body: message
+      message = twilio_service.api.account.messages.create from: @twilio_credentials[:number], to: to, body: message
       reference_id = message.sid if message
       SMSResponse.new true, 'twilio', reference_id
     end

--- a/lib/messaging_service/version.rb
+++ b/lib/messaging_service/version.rb
@@ -2,6 +2,6 @@
 
 module MessagingService
 
-  VERSION = '4.0.1'.freeze
+  VERSION = '4.0.1'
 
 end

--- a/messaging_service.gemspec
+++ b/messaging_service.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_runtime_dependency 'airbrake', ['> 4.0.0']
-  s.add_runtime_dependency 'twilio-ruby', ['~> 3.14.0']
+  s.add_runtime_dependency 'twilio-ruby', ['~> 5.0']
   s.add_runtime_dependency 'voodoo_sms', ['~> 1.1.1']
 
   s.add_development_dependency 'bundler', '~> 1.12'

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -170,7 +170,7 @@ describe MessagingService::SMS do
         end
 
         it 'tries Twilio first' do
-          expect(Twilio::REST::Client).to receive_message_chain(:new, :account, :messages, :create)
+          expect(Twilio::REST::Client).to receive_message_chain(:new, :api, :account, :messages, :create)
           expect(VoodooSMS).to_not receive(:new)
           response = subject.send(to: to_number, message: message)
           expect(response.service_provider).to eq 'twilio'


### PR DESCRIPTION
Update is needed to get access to date filtering options missing in version 3.