### PR TITLE
Set service provider when sms sending fails

### DIFF
--- a/.rubocop-https---raw-githubusercontent-com-dvmtn-house-style-master-rubocop-yml
+++ b/.rubocop-https---raw-githubusercontent-com-dvmtn-house-style-master-rubocop-yml
@@ -37,6 +37,14 @@ Layout/SpaceBeforeBlockBraces:
 # Style
 #
 
+Style/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'spec/**/*_spec.rb'
+    - 'spec/factories/**/*.rb'
+    - 'spec/spec_helper.rb'
+    - 'spec/support/shared_examples/*.rb'
+
 Style/DefWithParentheses:
   Enabled: false
 
@@ -110,14 +118,6 @@ Metrics/LineLength:
     - 'spec/**/*'
   Max: 140
   AllowURI: true
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*_spec.rb'
-    - 'spec/**/*_spec.rb'
-    - 'spec/factories/**/*.rb'
-    - 'spec/spec_helper.rb'
-    - 'spec/support/shared_examples/*.rb'
 
 #############################################
 # Security

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -26,7 +26,7 @@ module MessagingService
       return send_with_fallback_provider(to: to, message: message, timeout: timeout) if fallback_provider_provided?
 
       notify(e)
-      SMSResponse.new(false)
+      SMSResponse.new(false, @primary_provider.to_s)
     end
 
     private def send_with_primary_provider(to:, message:, timeout:)
@@ -37,10 +37,10 @@ module MessagingService
     private def send_with_fallback_provider(to:, message:, timeout:)
       return send_with_voodoo(to: to, message: message, timeout: timeout) if voodoo_fallback_provider?
       return send_with_twilio(to: to, message: message) if twilio_fallback_provider?
-      SMSResponse.new(false)
+      SMSResponse.new(false, @primary_provider.to_s)
     rescue StandardError => e
       notify(e)
-      SMSResponse.new(false)
+      SMSResponse.new(false, @primary_provider.to_s)
     end
 
     private def send_with_voodoo(to:, message:, timeout: 15)

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -96,6 +96,7 @@ describe MessagingService::SMS do
             notifier:           notifier
           )
         end
+
         it 'fails to send' do
           VCR.use_cassette('twilio/bad_request') do
             response = subject.send(to: to_number, message: message, timeout: 15)

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -87,6 +87,23 @@ describe MessagingService::SMS do
           end
         end
       end
+
+      context 'twilio is down and there is no fallback provider' do
+        subject do
+          described_class.new(
+            voodoo_credentials: voodoo_credentials,
+            primary_provider:   :twilio,
+            notifier:           notifier
+          )
+        end
+        it 'fails to send' do
+          VCR.use_cassette('twilio/bad_request') do
+            response = subject.send(to: to_number, message: message, timeout: 15)
+            expect(response.success).to eq false
+            expect(response.service_provider).to eq 'twilio'
+          end
+        end
+      end
     end
 
     context 'without a notifier' do
@@ -155,6 +172,7 @@ describe MessagingService::SMS do
           expect(VoodooSMS).to_not receive(:new)
           response = subject.send(to: to_number, message: message)
           expect(response.success).to eq false
+          expect(response.service_provider).to eq 'voodoo'
         end
       end
 
@@ -182,6 +200,7 @@ describe MessagingService::SMS do
           VCR.use_cassette('twilio/bad_request') do
             response = subject.send to: to_number, message: message, timeout: 15
             expect(response.success).to eq false
+            expect(response.service_provider).to eq 'voodoo'
           end
         end
       end
@@ -192,6 +211,7 @@ describe MessagingService::SMS do
           expect(VoodooSMS).to_not receive(:new)
           response = subject.send(to: to_number, message: message)
           expect(response.success).to eq false
+          expect(response.service_provider).to eq 'voodoo'
         end
       end
     end


### PR DESCRIPTION
I've just set it to the primary provider, since that's the one we should be using for that message, even if it was overridden at the time of sending.