### PR TITLE
Raise custom BlacklistedNumberError if SMS send fails due to Voodoo r…

### DIFF
--- a/.rubocop-https---raw-githubusercontent-com-dvmtn-house-style-master-rubocop-yml
+++ b/.rubocop-https---raw-githubusercontent-com-dvmtn-house-style-master-rubocop-yml
@@ -1,3 +1,8 @@
+inherit_mode:
+  merge:
+    - Exclude
+    - Include
+
 AllCops:
   Include:
     - '**/Rakefile'
@@ -33,17 +38,12 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/SpaceBeforeBlockBraces:
   Enabled: false
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 #############################################
 # Style
 #
-
-Style/BlockLength:
-  Exclude:
-    - 'spec/**/*_spec.rb'
-    - 'spec/**/*_spec.rb'
-    - 'spec/factories/**/*.rb'
-    - 'spec/spec_helper.rb'
-    - 'spec/support/shared_examples/*.rb'
 
 Style/DefWithParentheses:
   Enabled: false
@@ -84,6 +84,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
+Style/AccessModifierDeclarations:
+  EnforcedStyle: inline
+
 #############################################
 # Naming
 #
@@ -115,6 +118,13 @@ Lint/AssignmentInCondition:
 #############################################
 # Metrics
 #
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'spec/spec_helper.rb'
+    - 'spec/factories/**/*.rb'
+    - 'spec/support/shared_examples/*.rb'
 
 Metrics/LineLength:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     messaging_service (5.1.1)
       airbrake (> 4.0.0)
       twilio-ruby (~> 5.0)
-      voodoo_sms (~> 1.1.1)
+      voodoo_sms (> 1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -108,4 +108,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    messaging_service (5.1.0)
+    messaging_service (5.1.1)
       airbrake (> 4.0.0)
       twilio-ruby (~> 5.0)
       voodoo_sms (~> 1.1.1)
@@ -11,26 +11,30 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    airbrake (7.3.3)
-      airbrake-ruby (~> 2.10)
-    airbrake-ruby (2.10.0)
+    airbrake (7.4.0)
+      airbrake-ruby (~> 2.12)
+    airbrake-ruby (2.12.0)
     ast (2.4.0)
     byebug (10.0.2)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    faraday (0.15.1)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.3.7)
-    httparty (0.16.2)
+    httparty (0.16.3)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     jwt (2.1.0)
     method_source (0.9.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_portile2 (2.3.0)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parser (2.5.1.0)
@@ -74,7 +78,7 @@ GEM
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     tins (1.16.3)
-    twilio-ruby (5.10.1)
+    twilio-ruby (5.16.0)
       faraday (~> 0.9)
       jwt (>= 1.5, <= 2.5)
       nokogiri (>= 1.6, < 2.0)
@@ -104,4 +108,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/messaging_service.gemspec
+++ b/messaging_service.gemspec
@@ -10,15 +10,15 @@ Gem::Specification.new do |s|
   s.date        = '2017-04-20'
   s.summary     = 'Messaging Service'
   s.description = 'Shared SMS messaging services'
-  s.authors     = ['Tom Sabin']
-  s.email       = 'tom.sabin@unboxedconsulting.com'
+  s.authors     = ['Tom Sabin', 'SH:24']
+  s.email       = 'devops@sh24.org.uk'
   s.files       = ['lib/messaging_service']
   s.homepage    = 'https://github.com/sh24'
   s.license     = 'MIT'
 
   s.add_runtime_dependency 'airbrake', ['> 4.0.0']
   s.add_runtime_dependency 'twilio-ruby', ['~> 5.0']
-  s.add_runtime_dependency 'voodoo_sms', ['~> 1.1.1']
+  s.add_runtime_dependency 'voodoo_sms', ['> 1.1']
 
   s.add_development_dependency 'bundler', '~> 1.12'
   s.add_development_dependency 'pry'

--- a/spec/messaging_service/sms_spec.rb
+++ b/spec/messaging_service/sms_spec.rb
@@ -34,6 +34,17 @@ describe MessagingService::SMS do
       end
     end
 
+    context 'when Voodoo raises a blacklist error' do
+      let(:client){ TestClient.new }
+
+      it 'does not suppress the error' do
+        expect(VoodooSMS).to receive(:new).and_return(client)
+        expect(client).to receive(:send_sms).and_raise(VoodooSMS::Error::BadRequest, 'Black List Number Found')
+
+        expect { subject.send(to: '447870123456', message: 'Hello') }.to raise_error MessagingService::SMS::BlacklistedNumberError
+      end
+    end
+
     it 'request was successfully received at API' do
       VCR.use_cassette('voodoo_sms/send') do
         response = subject.send(to: to_number, message: message)


### PR DESCRIPTION
…eporting that a number has been blacklisted.

Required to make [this](https://github.com/sh24/admin/pull/1013) work properly.

Currently we swallow all exceptions raised when sending a message - in the instance of a blacklisted Voodoo number, we need to allow the exception to bubble up.

It'd probably be nicer to supply a failure reason in the `SMSResponse`, but I suspect that might require more effort than we've time for right now.