### PR TITLE
chore(metrics): measure message send stats

### DIFF
--- a/.rubocop_config.yml
+++ b/.rubocop_config.yml
@@ -221,6 +221,9 @@ Layout/LineLength:
   Max: 140
   AllowURI: true
 
+Metrics/ParameterLists:
+  Max: 6
+
 #############################################
 # Security
 #

--- a/lib/messaging_service.rb
+++ b/lib/messaging_service.rb
@@ -2,6 +2,7 @@
 
 require 'voodoo_sms'
 require 'twilio-ruby'
+require 'messaging_service/null_metrics_recorder'
 require 'messaging_service/integrations/base_integration'
 require 'messaging_service/integrations/voodoo_integration'
 require 'messaging_service/integrations/twilio_integration'

--- a/lib/messaging_service/null_metrics_recorder.rb
+++ b/lib/messaging_service/null_metrics_recorder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module MessagingService
+  class NullMetricsRecorder
+
+    def increment(*_args); end
+
+    def gauge(*_args); end
+
+    def timing(*_args); end
+
+    def measure(*_args)
+      yield
+    end
+
+  end
+end

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -11,13 +11,19 @@ module MessagingService
 
     Response = Struct.new(:success, :service_provider, :reference_id, :service_number)
 
-    def initialize(primary_provider:, voodoo_credentials: nil, twilio_credentials: nil, fallback_provider: nil, notifier: nil)
+    def initialize(primary_provider:,
+                   voodoo_credentials: nil,
+                   twilio_credentials: nil,
+                   fallback_provider: nil,
+                   notifier: nil,
+                   metrics_recorder: NullMetricsRecorder.new)
       raise_argument_error if no_credentials_provided?(voodoo_credentials, twilio_credentials)
 
       @voodoo_credentials = voodoo_credentials
       @twilio_credentials = twilio_credentials
       choose_integrations(primary_provider, fallback_provider)
       @notifier = notifier
+      @metrics_recorder = metrics_recorder
     end
 
     def send(to:, message:)
@@ -77,7 +83,8 @@ module MessagingService
         credentials[:password],
         credentials[:numbers],
         destination_number,
-        @notifier
+        @notifier,
+        metrics_recorder: @metrics_recorder
       )
     end
 

--- a/spec/messaging_service/integrations/voodoo_integration_spec.rb
+++ b/spec/messaging_service/integrations/voodoo_integration_spec.rb
@@ -7,28 +7,35 @@ module  MessagingService
 
     describe VoodooIntegration do
       describe '#send_message' do
-        context 'when the voodoo integration is disabled' do
-          let(:prefixed_service_numbers) { {} }
-          let(:destination_number) { '01234567890' }
-          let(:error_notifier) { double('notifier') }
+        let(:prefixed_service_numbers) { {} }
+        let(:destination_number) { '01234567890' }
+        let(:error_notifier) { double('notifier') }
+        let(:metrics_recorder) { double('metrics_recorder') }
 
+        before do
+          allow(error_notifier).to receive(:notify)
+          allow(metrics_recorder).to receive(:increment)
+          allow(metrics_recorder).to receive(:measure).and_yield
+        end
+
+        subject do
+          described_class.new(
+            'user',
+            'password',
+            prefixed_service_numbers,
+            destination_number,
+            error_notifier,
+            metrics_recorder: metrics_recorder
+          )
+        end
+
+        context 'when the voodoo integration is disabled' do
           before do
             ENV['VOODOO_DISABLE_MESSAGING'] = 'true'
-            allow(error_notifier).to receive(:notify)
           end
 
           after do
             ENV.delete('VOODOO_DISABLE_MESSAGING')
-          end
-
-          subject do
-            described_class.new(
-              'user',
-              'password',
-              prefixed_service_numbers,
-              destination_number,
-              error_notifier
-            )
           end
 
           it 'returns a failed status report' do
@@ -40,6 +47,12 @@ module  MessagingService
             subject.send_message('message')
             expect(error_notifier).to have_received(:notify)
           end
+        end
+
+        it 'records metrics' do
+          subject.send_message('message')
+          expect(metrics_recorder).to have_received(:increment).with('send_message/voodoo/result', status: 'failure')
+          expect(metrics_recorder).to have_received(:measure).with('send_message/voodoo/latency')
         end
       end
     end


### PR DESCRIPTION
 Record message send statistics (api call status, latency) for the voodoo and twilio integrations.

To avoid building a dependency-mess, instead of making this gem depend on the metrics library directly, the metrics recorder is passed in as an argument to `SMS`.

The `NullMetricsRecorder` default makes sure that instances of this library work even without a metrics client - as the ways of admin are mysterious and I'm not sure I will find all places where I have to update code.