### PR TITLE
feat: allow passing an account_sid when creating an SMS integration class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   working_directory: ~/repo
   parallelism: 1
   docker:
-    - image: circleci/ruby:2.5.1
+    - image: circleci/ruby:2.6.0
       environment:
         RAILS_ENV: test
         BUNDLER_VERSION: 2.0.2

--- a/lib/messaging_service/integrations/base_integration.rb
+++ b/lib/messaging_service/integrations/base_integration.rb
@@ -6,11 +6,12 @@ module MessagingService
 
       RESPONSE_TIMEOUT_SECONDS = 15
 
-      attr_reader :username, :password, :prefixed_service_numbers, :destination_number, :notifier, :metrics_recorder
+      attr_reader :username, :password, :prefixed_service_numbers, :destination_number, :notifier, :metrics_recorder, :account_sid
 
-      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, metrics_recorder:)
+      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid:, metrics_recorder:)
         @username = username
         @password = password
+        @account_sid = account_sid
         @prefixed_service_numbers = prefixed_service_numbers
         @destination_number = destination_number
         @notifier = notifier

--- a/lib/messaging_service/integrations/base_integration.rb
+++ b/lib/messaging_service/integrations/base_integration.rb
@@ -8,7 +8,7 @@ module MessagingService
 
       attr_reader :username, :password, :prefixed_service_numbers, :destination_number, :notifier, :metrics_recorder, :account_sid
 
-      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid:, metrics_recorder:) # rubocop:disable Metrics/ParameterLists
+      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid, metrics_recorder:) # rubocop:disable Metrics/ParameterLists
         @username = username
         @password = password
         @account_sid = account_sid

--- a/lib/messaging_service/integrations/base_integration.rb
+++ b/lib/messaging_service/integrations/base_integration.rb
@@ -8,7 +8,7 @@ module MessagingService
 
       attr_reader :username, :password, :prefixed_service_numbers, :destination_number, :notifier, :metrics_recorder, :account_sid
 
-      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid, metrics_recorder:) # rubocop:disable Metrics/ParameterLists
+      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid: nil, metrics_recorder:) # rubocop:disable Metrics/ParameterLists
         @username = username
         @password = password
         @account_sid = account_sid

--- a/lib/messaging_service/integrations/base_integration.rb
+++ b/lib/messaging_service/integrations/base_integration.rb
@@ -8,7 +8,7 @@ module MessagingService
 
       attr_reader :username, :password, :prefixed_service_numbers, :destination_number, :notifier, :metrics_recorder, :account_sid
 
-      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid: nil, metrics_recorder:) # rubocop:disable Metrics/ParameterLists
+      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, metrics_recorder:, account_sid: nil) # rubocop:disable Metrics/ParameterLists
         @username = username
         @password = password
         @account_sid = account_sid

--- a/lib/messaging_service/integrations/base_integration.rb
+++ b/lib/messaging_service/integrations/base_integration.rb
@@ -8,7 +8,7 @@ module MessagingService
 
       attr_reader :username, :password, :prefixed_service_numbers, :destination_number, :notifier, :metrics_recorder, :account_sid
 
-      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid:, metrics_recorder:)
+      def initialize(username, password, prefixed_service_numbers, destination_number, notifier, account_sid:, metrics_recorder:) # rubocop:disable Metrics/ParameterLists
         @username = username
         @password = password
         @account_sid = account_sid

--- a/lib/messaging_service/integrations/twilio_integration.rb
+++ b/lib/messaging_service/integrations/twilio_integration.rb
@@ -26,7 +26,7 @@ module MessagingService
       end
 
       def service
-        Twilio::REST::Client.new @username, @password
+        Twilio::REST::Client.new @username, @password, @account_sid
       end
 
     end

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -84,7 +84,7 @@ module MessagingService
         credentials[:numbers],
         destination_number,
         @notifier,
-        credentials[:account_sid],
+        account_sid: credentials[:account_sid],
         metrics_recorder: @metrics_recorder
       )
     end

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -84,7 +84,7 @@ module MessagingService
         credentials[:numbers],
         destination_number,
         @notifier,
-        account_sid: credentials[:account_sid],
+        credentials[:account_sid],
         metrics_recorder: @metrics_recorder
       )
     end

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -84,6 +84,7 @@ module MessagingService
         credentials[:numbers],
         destination_number,
         @notifier,
+        account_sid: credentials[:account_sid],
         metrics_recorder: @metrics_recorder
       )
     end


### PR DESCRIPTION
Allows us to authenticate twilio using an API key.