### PR TITLE
fix: account sid key not present in voodoo config

### DIFF
--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -84,7 +84,7 @@ module MessagingService
         credentials[:numbers],
         destination_number,
         @notifier,
-        account_sid: credentials[:account_sid],
+        account_sid: credentials.try(:account_sid), # account_sid is included in twilio config but not voodoo vonfig
         metrics_recorder: @metrics_recorder
       )
     end

--- a/lib/messaging_service/sms.rb
+++ b/lib/messaging_service/sms.rb
@@ -84,7 +84,7 @@ module MessagingService
         credentials[:numbers],
         destination_number,
         @notifier,
-        account_sid: credentials.try(:account_sid), # account_sid is included in twilio config but not voodoo vonfig
+        account_sid: credentials.try(:account_sid), # account_sid is included in twilio config but not voodoo config
         metrics_recorder: @metrics_recorder
       )
     end


### PR DESCRIPTION
Because `credentials` is an instance of `Config::Options`, not a regular hash, trying to access `account_sid when it isn’t present throws a KeyError rather than returning nil.  This lead to errors because `account_sid` is only present in twilio configs, not voodoo configs.